### PR TITLE
Caches the query results for ancestors to improve performance.

### DIFF
--- a/cwrc_projects.module
+++ b/cwrc_projects.module
@@ -764,25 +764,38 @@ function _cwrc_projects_og_context_logo() {
  * (or more than one parent project is found).
  */
 function _cwrc_projects_get_project($pid, $ancestors = NULL) {
+  // Passing in no ancestors means we should query for them.
   if ($ancestors === NULL) {
-    $ancestors = array();
+    $cid = __FUNCTION__ . ':' . $pid;
+    $ancestors = &drupal_static($cid);
+    if (!isset($ancestors)) {
+      if ($cache = cache_get($cid)) {
+        $ancestors = $cache->data;
+      }
+      else {
+        $ancestors = array();
 
-    // Get solarium client.
-    $client = cwrc_dashboards_get_solarium();
+        // Get solarium client.
+        $client = cwrc_dashboards_get_solarium();
 
-    // Build select query determining ancestry.
-    $query = $client->createSelect();
-    $query->setQuery('PID:"' . $pid . '"')
-      ->setFields(array("ancestors_ms"))
-      ->addSort('workflow_date_current_dt', $query::SORT_DESC)
-      ->setRows(1);
+        // Build select query determining ancestry.
+        $query = $client->createSelect();
+        $query->setQuery('PID:"' . $pid . '"')
+          ->setFields(array("ancestors_ms"))
+          ->addSort('workflow_date_current_dt', $query::SORT_DESC)
+          ->setRows(1);
 
-    // Get query results.
-    $results = $client->select($query);
+        // Get query results.
+        $results = $client->select($query);
 
-    // Set the new ancestors.
-    if ($results->getNumFound() > 0) {
-      $ancestors = $results->getDocuments()[0]['ancestors_ms'];
+        // Set the new ancestors.
+        if ($results->getNumFound() > 0) {
+          $ancestors = $results->getDocuments()[0]['ancestors_ms'];
+        }
+
+        // Cache this result for one week to avoid hammering SOLR.
+        cache_set($cid, $ancestors, 'cache', time() + 604800);
+      }
     }
   }
 


### PR DESCRIPTION
# Problem / motivation

Performance on collection and search pages was suffering due to large amount of queries being executed on these pages (one per rendered object).  This is caused by the teaser preprocess calling `_cwrc_projects_get_project`, which queries solr for a list of ancestor objects (this data is not stored on an object, we could execute a SPARQL query to get it, but this is likely going to make performance worse).

# Proposed resolution

Cache the results of querying for ancestors in `_cwrc_projects_get_project` to avoid hammering the solr server.

# Remaining tasks

(none)

# User interface changes

(none)

# API changes

(none)

# Data model changes

Results of querying for ancestors in this function will be cached for one week..
